### PR TITLE
Skip redirect override when debugging

### DIFF
--- a/Part 4 - Reliability/finished/Relecloud.Web/Startup.cs
+++ b/Part 4 - Reliability/finished/Relecloud.Web/Startup.cs
@@ -212,29 +212,32 @@ namespace Relecloud.Web
             });
 
             services.Configure<OpenIdConnectOptions>(Configuration.GetSection("AzureAd"));
-            services.Configure((Action<MicrosoftIdentityOptions>)(options =>
+            if (!Debugger.IsAttached)
             {
-                var frontDoorUri = Configuration["App:FrontDoorUri"];
-                var callbackPath = Configuration["AzureAd:CallbackPath"];
-
-                options.Events = new OpenIdConnectEvents
+                services.Configure((Action<MicrosoftIdentityOptions>)(options =>
                 {
-                    OnRedirectToIdentityProvider = ctx => {
-                        // not needed when using host name preservation
-                        ctx.ProtocolMessage.RedirectUri = $"https://{frontDoorUri}{callbackPath}";
-                        return Task.CompletedTask;
-                    },
-                    OnRedirectToIdentityProviderForSignOut = ctx => {
-                        // not needed when using host name preservation
-                        ctx.ProtocolMessage.PostLogoutRedirectUri = $"https://{frontDoorUri}";
-                        return Task.CompletedTask;
-                    },
-                    OnTokenValidated = async ctx =>
+                    var frontDoorUri = Configuration["App:FrontDoorUri"];
+                    var callbackPath = Configuration["AzureAd:CallbackPath"];
+
+                    options.Events = new OpenIdConnectEvents
                     {
-                        await CreateOrUpdateUserInformation(ctx);
-                    }
-                };
-            }));
+                        OnRedirectToIdentityProvider = ctx => {
+                            // not needed when using host name preservation
+                            ctx.ProtocolMessage.RedirectUri = $"https://{frontDoorUri}{callbackPath}";
+                            return Task.CompletedTask;
+                        },
+                        OnRedirectToIdentityProviderForSignOut = ctx => {
+                            // not needed when using host name preservation
+                            ctx.ProtocolMessage.PostLogoutRedirectUri = $"https://{frontDoorUri}";
+                            return Task.CompletedTask;
+                        },
+                        OnTokenValidated = async ctx =>
+                        {
+                            await CreateOrUpdateUserInformation(ctx);
+                        }
+                    };
+                }));
+            }
         }
 
         private static async Task CreateOrUpdateUserInformation(TokenValidatedContext ctx)

--- a/Part 4 - Reliability/src/Relecloud.Web/Startup.cs
+++ b/Part 4 - Reliability/src/Relecloud.Web/Startup.cs
@@ -183,29 +183,32 @@ namespace Relecloud.Web
             });
 
             services.Configure<OpenIdConnectOptions>(Configuration.GetSection("AzureAd"));
-            services.Configure((Action<MicrosoftIdentityOptions>)(options =>
+            if (!Debugger.IsAttached)
             {
-                var frontDoorUri = Configuration["App:FrontDoorUri"];
-                var callbackPath = Configuration["AzureAd:CallbackPath"];
-
-                options.Events = new OpenIdConnectEvents
+                services.Configure((Action<MicrosoftIdentityOptions>)(options =>
                 {
-                    OnRedirectToIdentityProvider = ctx => {
-                        // not needed when using host name preservation
-                        ctx.ProtocolMessage.RedirectUri = $"https://{frontDoorUri}{callbackPath}";
-                        return Task.CompletedTask;
-                    },
-                    OnRedirectToIdentityProviderForSignOut = ctx => {
-                        // not needed when using host name preservation
-                        ctx.ProtocolMessage.PostLogoutRedirectUri = $"https://{frontDoorUri}";
-                        return Task.CompletedTask;
-                    },
-                    OnTokenValidated = async ctx =>
+                    var frontDoorUri = Configuration["App:FrontDoorUri"];
+                    var callbackPath = Configuration["AzureAd:CallbackPath"];
+
+                    options.Events = new OpenIdConnectEvents
                     {
-                        await CreateOrUpdateUserInformation(ctx);
-                    }
-                };
-            }));
+                        OnRedirectToIdentityProvider = ctx => {
+                            // not needed when using host name preservation
+                            ctx.ProtocolMessage.RedirectUri = $"https://{frontDoorUri}{callbackPath}";
+                            return Task.CompletedTask;
+                        },
+                        OnRedirectToIdentityProviderForSignOut = ctx => {
+                            // not needed when using host name preservation
+                            ctx.ProtocolMessage.PostLogoutRedirectUri = $"https://{frontDoorUri}";
+                            return Task.CompletedTask;
+                        },
+                        OnTokenValidated = async ctx =>
+                        {
+                            await CreateOrUpdateUserInformation(ctx);
+                        }
+                    };
+                }));
+            }
         }
 
         private static async Task CreateOrUpdateUserInformation(TokenValidatedContext ctx)

--- a/Part 7 - Performance Efficiency/finished/Relecloud.Web/Startup.cs
+++ b/Part 7 - Performance Efficiency/finished/Relecloud.Web/Startup.cs
@@ -212,29 +212,32 @@ namespace Relecloud.Web
             });
 
             services.Configure<OpenIdConnectOptions>(Configuration.GetSection("AzureAd"));
-            services.Configure((Action<MicrosoftIdentityOptions>)(options =>
+            if (!Debugger.IsAttached)
             {
-                var frontDoorUri = Configuration["App:FrontDoorUri"];
-                var callbackPath = Configuration["AzureAd:CallbackPath"];
-
-                options.Events = new OpenIdConnectEvents
+                services.Configure((Action<MicrosoftIdentityOptions>)(options =>
                 {
-                    OnRedirectToIdentityProvider = ctx => {
-                        // not needed when using host name preservation
-                        ctx.ProtocolMessage.RedirectUri = $"https://{frontDoorUri}{callbackPath}";
-                        return Task.CompletedTask;
-                    },
-                    OnRedirectToIdentityProviderForSignOut = ctx => {
-                        // not needed when using host name preservation
-                        ctx.ProtocolMessage.PostLogoutRedirectUri = $"https://{frontDoorUri}";
-                        return Task.CompletedTask;
-                    },
-                    OnTokenValidated = async ctx =>
+                    var frontDoorUri = Configuration["App:FrontDoorUri"];
+                    var callbackPath = Configuration["AzureAd:CallbackPath"];
+
+                    options.Events = new OpenIdConnectEvents
                     {
-                        await CreateOrUpdateUserInformation(ctx);
-                    }
-                };
-            }));
+                        OnRedirectToIdentityProvider = ctx => {
+                            // not needed when using host name preservation
+                            ctx.ProtocolMessage.RedirectUri = $"https://{frontDoorUri}{callbackPath}";
+                            return Task.CompletedTask;
+                        },
+                        OnRedirectToIdentityProviderForSignOut = ctx => {
+                            // not needed when using host name preservation
+                            ctx.ProtocolMessage.PostLogoutRedirectUri = $"https://{frontDoorUri}";
+                            return Task.CompletedTask;
+                        },
+                        OnTokenValidated = async ctx =>
+                        {
+                            await CreateOrUpdateUserInformation(ctx);
+                        }
+                    };
+                }));
+            }
         }
 
         private static async Task CreateOrUpdateUserInformation(TokenValidatedContext ctx)

--- a/Part 7 - Performance Efficiency/start/Relecloud.Web/Startup.cs
+++ b/Part 7 - Performance Efficiency/start/Relecloud.Web/Startup.cs
@@ -213,29 +213,32 @@ namespace Relecloud.Web
             });
 
             services.Configure<OpenIdConnectOptions>(Configuration.GetSection("AzureAd"));
-            services.Configure((Action<MicrosoftIdentityOptions>)(options =>
+            if (!Debugger.IsAttached)
             {
-                var frontDoorUri = Configuration["App:FrontDoorUri"];
-                var callbackPath = Configuration["AzureAd:CallbackPath"];
-
-                options.Events = new OpenIdConnectEvents
+                services.Configure((Action<MicrosoftIdentityOptions>)(options =>
                 {
-                    OnRedirectToIdentityProvider = ctx => {
-                        // not needed when using host name preservation
-                        ctx.ProtocolMessage.RedirectUri = $"https://{frontDoorUri}{callbackPath}";
-                        return Task.CompletedTask;
-                    },
-                    OnRedirectToIdentityProviderForSignOut = ctx => {
-                        // not needed when using host name preservation
-                        ctx.ProtocolMessage.PostLogoutRedirectUri = $"https://{frontDoorUri}";
-                        return Task.CompletedTask;
-                    },
-                    OnTokenValidated = async ctx =>
+                    var frontDoorUri = Configuration["App:FrontDoorUri"];
+                    var callbackPath = Configuration["AzureAd:CallbackPath"];
+
+                    options.Events = new OpenIdConnectEvents
                     {
-                        await CreateOrUpdateUserInformation(ctx);
-                    }
-                };
-            }));
+                        OnRedirectToIdentityProvider = ctx => {
+                            // not needed when using host name preservation
+                            ctx.ProtocolMessage.RedirectUri = $"https://{frontDoorUri}{callbackPath}";
+                            return Task.CompletedTask;
+                        },
+                        OnRedirectToIdentityProviderForSignOut = ctx => {
+                            // not needed when using host name preservation
+                            ctx.ProtocolMessage.PostLogoutRedirectUri = $"https://{frontDoorUri}";
+                            return Task.CompletedTask;
+                        },
+                        OnTokenValidated = async ctx =>
+                        {
+                            await CreateOrUpdateUserInformation(ctx);
+                        }
+                    };
+                }));
+            }
         }
 
         private static async Task CreateOrUpdateUserInformation(TokenValidatedContext ctx)

--- a/Reference App/src/Relecloud.Web/Startup.cs
+++ b/Reference App/src/Relecloud.Web/Startup.cs
@@ -212,29 +212,32 @@ namespace Relecloud.Web
             });
 
             services.Configure<OpenIdConnectOptions>(Configuration.GetSection("AzureAd"));
-            services.Configure((Action<MicrosoftIdentityOptions>)(options =>
+            if (!Debugger.IsAttached)
             {
-                var frontDoorUri = Configuration["App:FrontDoorUri"];
-                var callbackPath = Configuration["AzureAd:CallbackPath"];
-
-                options.Events = new OpenIdConnectEvents
+                services.Configure((Action<MicrosoftIdentityOptions>)(options =>
                 {
-                    OnRedirectToIdentityProvider = ctx => {
-                        // not needed when using host name preservation
-                        ctx.ProtocolMessage.RedirectUri = $"https://{frontDoorUri}{callbackPath}";
-                        return Task.CompletedTask;
-                    },
-                    OnRedirectToIdentityProviderForSignOut = ctx => {
-                        // not needed when using host name preservation
-                        ctx.ProtocolMessage.PostLogoutRedirectUri = $"https://{frontDoorUri}";
-                        return Task.CompletedTask;
-                    },
-                    OnTokenValidated = async ctx =>
+                    var frontDoorUri = Configuration["App:FrontDoorUri"];
+                    var callbackPath = Configuration["AzureAd:CallbackPath"];
+
+                    options.Events = new OpenIdConnectEvents
                     {
-                        await CreateOrUpdateUserInformation(ctx);
-                    }
-                };
-            }));
+                        OnRedirectToIdentityProvider = ctx => {
+                            // not needed when using host name preservation
+                            ctx.ProtocolMessage.RedirectUri = $"https://{frontDoorUri}{callbackPath}";
+                            return Task.CompletedTask;
+                        },
+                        OnRedirectToIdentityProviderForSignOut = ctx => {
+                            // not needed when using host name preservation
+                            ctx.ProtocolMessage.PostLogoutRedirectUri = $"https://{frontDoorUri}";
+                            return Task.CompletedTask;
+                        },
+                        OnTokenValidated = async ctx =>
+                        {
+                            await CreateOrUpdateUserInformation(ctx);
+                        }
+                    };
+                }));
+            }
         }
 
         private static async Task CreateOrUpdateUserInformation(TokenValidatedContext ctx)


### PR DESCRIPTION
During local development flows the Entra ID redirects should not leverage Azure Front Door to address the host name preservation issue.